### PR TITLE
enable setting CONFIG & CACHE filenames via ENV vars

### DIFF
--- a/phptidy.php
+++ b/phptidy.php
@@ -115,9 +115,8 @@ $indent                     = true;
 
 ///////////// END OF DEFAULT CONFIGURATION ////////////////
 
-
-define('CONFIGFILE', "./.phptidy-config.php");
-define('CACHEFILE', "./.phptidy-cache");
+define('CONFIGFILE', getenv('PHPTIDY_CONFIGFILE') ? getenv('PHPTIDY_CONFIGFILE') : "./.phptidy-config.php");
+define('CACHEFILE', getenv('PHPTIDY_CACHEFILE') ? getenv('PHPTIDY_CACHEFILE') : "./.phptidy-cache");
 
 
 error_reporting(E_ALL);


### PR DESCRIPTION
this PR consists of 2 changes:

- 70e0efcf3015302160356a788214a5ed7ae7a6f8
  fixes the 'each() function is deprecated' issue #16

- 8bc35aba941b5f31b29264af9dd7942e2c5d213d
  allows setting the two file names for `CONFIGFILE` and `CACHEFILE` using environment variables `PHPTIDY_CONFIGFILE`and `PHPTIDY_CACHEFILE`

  With the fixed filenames we often get `Warning: file_put_contents(./.phptidy-cache): failed to open stream: Permission denied in...` errors when calling phptidy.php in scripts whose $PWD is in directories where they do not have write access.
